### PR TITLE
Align manifest.json with RO-Lite work

### DIFF
--- a/metadata/manifest.json
+++ b/metadata/manifest.json
@@ -1,17 +1,14 @@
 {
   "@context": [
+    "https://schema.org/",
     "https://w3id.org/bundle/context",
     {
-      "schema": "http://schema.org/"
-    },
-    {
-      "Datasets": {
-        "@type": "@id"
-      }
+      "name": "http://schema.org/name"
     }
   ],
   "@id": "https://data.wholetale.org/api/v1/tale/5c875b6feff2c60001d2810f",
-  "Datasets": [
+  "@type": ["DataCatalog", "ro:ResearchObject"],
+  "dataset": [
     {
       "@id": "doi:10.5065/D6862DM8",
       "@type": "Dataset",
@@ -20,12 +17,14 @@
       "publisher": {
         "@id": "https://www.dataone.org/",
         "@type": "Organization",
-        "Description": "A federated data network allowing access to science data",
+        "description": "A federated data network allowing access to science data",
         "legalName": "DataONE"
       }
     }
   ],
   "aggregates": [
+    { "uri": "doi:10.5065/D6862DM8",
+    }
     {
       "uri": "../../workspace/requirements.txt"
     },
@@ -38,33 +37,35 @@
     {
       "bundledAs": {
         "filename": "usco2005.xls",
-        "folder": "../data/data/Humans and Hydrology at High Latitudes: Water Use Information"
+        "folder": "../data/data/Humans%20and%20Hydrology%20at%20High%20Latitudes%3a%20Water%20Use%20Information"
       },
-      "schema:isPartOf": "doi:10.5065/D6862DM8",
+      "isPartOf": "doi:10.5065/D6862DM8",
       "uri": "https://cn.dataone.org/cn/v2/resolve/urn:uuid:01a53103-8db1-46b3-967c-b42acf69ae08"
     },
     {
-      "schema:license": "CC-BY-4.0",
-      "uri": "../LICENSE"
+      "uri": "../LICENSE",
+      "sameAs": "https://creativecommons.org/licenses/by/4.0/"
+
     },
     {
-      "@type": "schema:HowTo",
+      "@type": "HowTo",
       "uri": "../README.txt"
     }
   ],
-  "createdBy": {
-    "@id": "Craig Willis",
-    "@type": "schema:Person",
-    "schema:email": "willis8@illinois.edu",
-    "schema:familyName": "Willis",
-    "schema:givenName": "Craig"
+  "creator": {
+    "@id": "https://orcid.org/0000-0002-6148-7196",
+    "@type": "Person",
+    "name": "Craig Willis",   
+    "email": "willis8@illinois.edu",
+    "familyName": "Willis",
+    "givenName": "Craig"
   },
-  "createdOn": "2019-03-12 07:10:39.846000",
-  "schema:category": "Examples",
-  "schema:description": "Description of my example Tale.",
-  "schema:identifier": "5c875b6feff2c60001d2810f",
-  "schema:image": "https://raw.githubusercontent.com/whole-tale/images/demo-graph2.jpg",
-  "schema:name": "Example Tale",
-  "schema:version": 6
+  "dateCreated": "2019-03-12 07:10:39.846000",
+  "keywords": "Example",
+  "description": "Description of my example Tale.",
+  "identifier": "5c875b6feff2c60001d2810f",
+  "image": "https://raw.githubusercontent.com/whole-tale/images/demo-graph2.jpg",
+  "name": "Example Tale",
+  "version": 6,
+  "license": "../LICENSE"
 }
-

--- a/metadata/manifest.json
+++ b/metadata/manifest.json
@@ -23,8 +23,8 @@
     }
   ],
   "aggregates": [
-    { "uri": "doi:10.5065/D6862DM8",
-    }
+    { "uri": "doi:10.5065/D6862DM8"
+    },
     {
       "uri": "../../workspace/requirements.txt"
     },


### PR DESCRIPTION
Hi, in @kylechard asked me to have a look at this, as in [RO-Lite](https://researchobject.github.io/ro-lite/) we are trying to formalize exactly what you are trying to do.  


This patch is aligning the `manifest.json` closer to https://researchobject.github.io/ro-lite/0.1.0/ draft but without the suggested relocation it to `/manifest.jsonld` so that this is still valid according to existing BDBag.

* `Description` typo -> `description` (for http://schema.org/description)
* Use http://schema.org/ context, avoids `"@type": "@id"` mapping and `schema:` prefix
* Modified `license` (as we're not so interested in license of the license file) - express on the overall RO
* Use schema.org over foaf
* schema.org JSON-LD blocks can be used directly as in examples
* Fixed missing URI escaping in `folder` (good example!)
* Fixed `@id` of the person so it's an actual URI - here using ORCID (as in RO-lite directly rather than with `orcid` property)
* http://schema.org/keywords instead of http://schema.org/category as `category` does not apply to http://schema.org/CreativeWork (alternative: relate it to https://schema.org/exampleOfWork if there's something it's an example of)
* http://schema.org/creator http://schema.org/createdDate instead of `pav:createdBy` and `pav:createdDate`
* Use http://schema.org/dataset as main holder, which makes the `ro:ResearchObject` also be a http://schema.org/DataCatalog and implicit  `@type: Dataset`
* "duplicate" `dataset` relation in `aggregate` so that the doi `Dataset` instance is also part of the RO

Try the JSON-LD in https://json-ld.org/playground/ and click **Table** to check the triples are in the correct namespaces etc.

https://search.google.com/structured-data/testing-tool is not ideal as it gets [upset on properties](https://search.google.com/structured-data/testing-tool/u/0/#url=https%3A%2F%2Fgist.githubusercontent.com%2Fstain%2F76cb9c4311736f5af25810b4dff7714a%2Fraw%2F7f12df9771e4ef5e4edae2e45fde5e116c2b657c%2Fmanifest.jsonld) from non-schema.org vocabularies  (which are harmless according to @danbri) - but at least it flags mistakes like `Description` vs `description`

In the RO-Lite work we want to move towards formalizing this approach, so we would likely make a new JSON-LD context to avoids the tricky "@context: [...]" hacks above.

If you are interested you can join https://github.com/ResearchObject/ro-lite/issues/1 and help us shape RO Lite. 

Alternative 1 - all schema.org: https://gist.github.com/stain/2673f4c920a86d1b257cc0a696b32df4 (RO and bdbag tools does not know this yet)
Alternative 2 - schema: prefix only: https://gist.github.com/stain/93686e8e557f13e8edccc15a767e8499  (works just as well in https://search.google.com/structured-data/testing-tool - but JSON looks more noisy as `schema:` properties become more "imported"

This patch is a "middle ground" of those two approaches, preserving in particular the OAI-ORE aggregation aspect of research objects.